### PR TITLE
Update the v2 URL once more

### DIFF
--- a/nta.py
+++ b/nta.py
@@ -4,7 +4,7 @@ import prometheus_client    # type: ignore[import]
 
 
 TEST_URL = "https://api.nationaltransport.ie/gtfsrtest/"
-PROD_URL = "https://api.nationaltransport.ie/gtfsr/v2/gtfsr"
+PROD_URL = "https://api.nationaltransport.ie/gtfsr/v2/TripUpdates"
 
 # Metrics
 LATENCY = prometheus_client.Summary(


### PR DESCRIPTION
Per the NTA support team, even the new GTFSR URL was not long for this world.