### PR TITLE
Fix to 24+ hr times from the schedule/feed, vscode support and Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,9 @@
 
 # Ignore some Python caches
 /.mypy_cache
-/__pycache__
+__pycache__
 
 /google_transit_combined
+/GTFS_Realtime
 /venv
 /config.ini

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run server",
+            "type": "python",
+            "request": "launch",
+            "stopOnEntry": false,
+            "program": "${workspaceFolder}/main.py",
+            "args": [
+                "--config=config.ini",
+                "--env=prod",
+                "--port=6824",
+                "--gtfs=GTFS_Realtime"
+            ],
+            "justMyCode": true,
+            
+        }
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,6 +18,15 @@
             ],
             "justMyCode": true,
             
+        },
+        {
+            "name": "Run tests",
+            "type": "python",
+            "request": "launch",
+            "stopOnEntry": false,
+            "program": "${workspaceFolder}/transit_test.py",
+            "justMyCode": true,
+            
         }
     ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+ARG BUILD_FROM=alpine
+FROM $BUILD_FROM
+
+ARG GTFS_UPCOMING_ZIP_URL=https://github.com/seanblanchfield/gtfs-upcoming/archive/refs/heads/main.zip
+ARG TFI_GTFS_ZIP=https://www.transportforireland.ie/transitData/Data/GTFS_Realtime.zip
+
+# Install requirements for add-on
+RUN \
+  apk add --no-cache \
+    python3 \
+    py3-pip \
+    wget \
+    unzip
+
+WORKDIR /app
+
+# Get the GTFS Upcoming python app and install dependencies
+RUN wget $GTFS_UPCOMING_ZIP_URL
+RUN unzip main.zip
+RUN rm main.zip
+RUN mv gtfs-upcoming-main/* .
+RUN python3 -m pip install -r requirements.txt
+
+# Get the TFI GTFS Realtime data
+RUN wget $TFI_GTFS_ZIP
+RUN unzip GTFS_Realtime.zip -d GTFS_Realtime
+
+ENTRYPOINT [ "python3", "main.py" ]

--- a/README.md
+++ b/README.md
@@ -84,6 +84,21 @@ then building/running is trivial:
 
 The BUILD file also defines a Debian (.deb) build target.
 
+## Docker
+A Dockerfile is provided, which installs the latest master code from github, and the 
+GTFS-R zip file from the link above. Build the docker file as follows:
+
+``` bash
+docker build . --tag tfi_gtfs
+```
+You run it with a `config.ini` from your project directory as follows:
+
+``` bash
+docker run -v ./config.ini:/app/config.ini:ro -p 6824:6824 tfi_gtfs --config=config.ini --env=prod --port=6824 --gtfs=GTFS_Realtime
+```
+
+You should now be able to access the API on your local machine.
+
 ## Data and Configuration
 
 ### GTFS Data

--- a/transit.py
+++ b/transit.py
@@ -56,13 +56,16 @@ def now() -> datetime.datetime:
 
 def parseTime(t: str) -> datetime.datetime:
   """Converts HH:MM:SS to a datetime.datetime"""
-  return datetime.datetime.strptime(t, '%H:%M:%S')
+  base_date = now().date()
+  if t.startswith('24:'):
+    t = t.replace('24:', '00:')
+    base_date += datetime.timedelta(days=1)
+  return datetime.datetime.combine(base_date, datetime.datetime.strptime(t, '%H:%M:%S').time())
 
 
-def delta_seconds(now: datetime.time, then: datetime.time) -> float:
+def delta_seconds(now: datetime.datetime, then: datetime.datetime) -> float:
   """Returns time in seconds between two datetime.times"""
-  td = lambda t : datetime.timedelta(hours=t.hour, minutes=t.minute, seconds=t.second)
-  return (td(now) - td(then)).total_seconds()
+  return (now - then).total_seconds()
 
 
 class Upcoming(NamedTuple):
@@ -82,7 +85,7 @@ class Upcoming(NamedTuple):
     return self._asdict()
 
   @classmethod
-  def FromTrip(cls, trip: gtfs_data.database.Trip, stop_id: str, source: str, due: str, currentTime: datetime.time):
+  def FromTrip(cls, trip: gtfs_data.database.Trip, stop_id: str, source: str, due: str, currentDateTime: datetime.datetime):
     return cls(
       trip_id=trip.trip_id,
       route=trip.route['route_short_name'],
@@ -91,7 +94,7 @@ class Upcoming(NamedTuple):
       direction=trip.direction_id,
       stop_id=stop_id,
       dueTime=due,
-      dueInSeconds=delta_seconds(parseTime(due).time(), currentTime),
+      dueInSeconds=delta_seconds(parseTime(due), currentDateTime),
       source=source)
 
 
@@ -122,11 +125,9 @@ class Transit:
         for s in t.stop_times:
           if s['stop_id'] == stop_id:
             due = s['arrival_time']
-            if due.startswith('24:'):
-              due = due.replace('24:', '00:')
             break
 
-        ret.append(Upcoming.FromTrip(t, stop_id, 'SCHEDULE', due, now().time()))
+        ret.append(Upcoming.FromTrip(t, stop_id, 'SCHEDULE', due, now()))
 
     SCHEDULED_RETURNED.observe(len(ret))
 
@@ -167,8 +168,6 @@ class Transit:
         if st['stop_id'] in interesting_stops:
           stop_id = st['stop_id']
           sequence = int(st['stop_sequence'])
-          if st['arrival_time'].startswith('24:'):
-            st['arrival_time'] = st['arrival_time'].replace('24:', '00:')
           arrival_time = parseTime(st['arrival_time'])
           break
 
@@ -180,13 +179,15 @@ class Transit:
               secs = int(stu.arrival.delay)
               updated_arrival_time += datetime.timedelta(seconds=secs)
             if stu.arrival.HasField('time'):
+              # parses POSIX timestamp into datetime
+              # (https://developers.google.com/transit/gtfs-realtime/reference#message-feedentity)
               updated_arrival_time = datetime.datetime.fromtimestamp(
                 stu.arrival.time)
         else:
             # We don't need to read anything past our stop.
             break
 
-      if current.time() > updated_arrival_time.time():
+      if current > updated_arrival_time:
         continue
 
       if updated_arrival_time < arrival_time:
@@ -197,7 +198,7 @@ class Transit:
         delayed += 1
 
       due = updated_arrival_time.strftime("%H:%M:%S")
-      ret.append(Upcoming.FromTrip(trip_from_db, stop_id, 'LIVE', due, current.time()))
+      ret.append(Upcoming.FromTrip(trip_from_db, stop_id, 'LIVE', due, current))
 
     MATCHED_TRIPS.labels('ontime').observe(ontime)
     MATCHED_TRIPS.labels('early').observe(early)

--- a/transit.py
+++ b/transit.py
@@ -122,6 +122,8 @@ class Transit:
         for s in t.stop_times:
           if s['stop_id'] == stop_id:
             due = s['arrival_time']
+            if due.startswith('24:'):
+              due = due.replace('24:', '00:')
             break
 
         ret.append(Upcoming.FromTrip(t, stop_id, 'SCHEDULE', due, now().time()))
@@ -165,6 +167,8 @@ class Transit:
         if st['stop_id'] in interesting_stops:
           stop_id = st['stop_id']
           sequence = int(st['stop_sequence'])
+          if st['arrival_time'].startswith('24:'):
+            st['arrival_time'] = st['arrival_time'].replace('24:', '00:')
           arrival_time = parseTime(st['arrival_time'])
           break
 

--- a/transit_test.py
+++ b/transit_test.py
@@ -33,10 +33,15 @@ class TestTransit(unittest.TestCase):
     """Simple wrapper to allow a test to specify which file it wants."""
     return fetch(self.fetch_input)
 
+  def testParseTime(self):
+    now = transit.now()
+    self.assertEqual(transit.parseTime("24:20:00").date() - now.date(), datetime.timedelta(days=1))
+
   def testDelta_Seconds(self):
-    t1 = datetime.time(10, 40, 00)
-    t2 = datetime.time(10, 45, 30)
-    t3 = datetime.time(15, 40, 00)
+    now = datetime.datetime(2023, 8, 21)
+    t1 = datetime.datetime.combine(now, datetime.time(10, 40, 00))
+    t2 = datetime.datetime.combine(now, datetime.time(10, 45, 30))
+    t3 = datetime.datetime.combine(now, datetime.time(15, 40, 00))
 
     self.assertEqual(transit.delta_seconds(t1, t2), -330)
     self.assertEqual(transit.delta_seconds(t2, t1), 330)


### PR DESCRIPTION
Sorry to lump a few different things into this PR. You can reject what you don't want.

The primary content are fixes in `transit.py` for the TFI schedule containing times that are greater than 24 hours (e.g., "24:23:00") to indicate times in the subsequent day. These were causing crash bugs when `strptime()` was called on them. This happened close to midnight, and I could reproduce by temporarily hardcoding the time to be just before midnight.  I tried to fix this with minimal changes, and my strategy is to switch to using `datetime` instead of `time` when handling these timestamps and to increment these `datetime`s by one day when necessary (similar to your existing strategy in `gtfs_data/database.py` for the same problem). This allows them to be accurately compared and for `dueInSeconds` to be calculated.  I updated the tests accordingly and added on more test. Everything seems to be working.

Since I was working in vscode, which seems to be the most popular IDE right now, I added a vscode `launch.json` file so that the project can be easily debugged (both running the server and running the tests).

I also committed a Dockerfile before making this PR, so that's in it too. I added instructions to the README on how to use the dockerfile.