### PR TITLE
Fix a DeprecationWarning (os.fork()) in Python 3.12

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -127,6 +127,7 @@ py_library(
 
 py_test(
     name = "transit_test",
+    size = "small",
     srcs = ["transit_test.py"],
     data = [
         "testdata/gtfsv1-sample-onetrip.json",

--- a/gtfs_data/BUILD
+++ b/gtfs_data/BUILD
@@ -11,6 +11,7 @@ py_library(
 
 py_test(
     name = "loader_test",
+    size = "small",
     srcs = ["loader_test.py"],
     data = [
         "testdata/agency.txt",
@@ -43,6 +44,7 @@ filegroup(
 
 py_test(
     name = "database_test",
+    size = "small",
     srcs = ["database_test.py"],
     data = [
         ":exported_testdata",

--- a/gtfs_data/database_test.py
+++ b/gtfs_data/database_test.py
@@ -1,6 +1,7 @@
 import gtfs_data.database
 
 import datetime
+import multiprocessing
 import unittest
 
 TEST_FILE = 'gtfs_data/testdata/agency.txt'
@@ -205,4 +206,5 @@ class TestDatabase(unittest.TestCase):
     self.assertEqual(len(gtfs_data.database.CALENDAR_DAYS), 7)
 
 if __name__ == '__main__':
+    multiprocessing.set_start_method("spawn")
     unittest.main()

--- a/gtfs_data/loader_test.py
+++ b/gtfs_data/loader_test.py
@@ -1,5 +1,6 @@
 import gtfs_data.loader
 
+import multiprocessing
 import unittest
 
 TEST_FILE = 'gtfs_data/testdata/agency.txt'
@@ -38,4 +39,5 @@ class TestLoader(unittest.TestCase):
     self.assertIn('service_id', result[0].keys())
 
 if __name__ == '__main__':
+    multiprocessing.set_start_method("spawn")
     unittest.main()

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ import faulthandler
 import functools
 import json
 import logging
+import multiprocessing
 import os
 import sys
 import time
@@ -158,6 +159,7 @@ def main(argv: List[str]) -> None:
 
   gtfs_data.loader.MaxThreads = int(args.loader_max_threads)
   gtfs_data.loader.MaxRowsPerChunk = int(args.loader_max_rows_per_chunk)
+  multiprocessing.set_start_method("spawn")
 
   logging.info('Configured loader with %d threads, %d rows per chunk',
     gtfs_data.loader.MaxThreads, gtfs_data.loader.MaxRowsPerChunk)

--- a/transit_test.py
+++ b/transit_test.py
@@ -1,4 +1,5 @@
 import gtfs_data.database
+import multiprocessing
 import transit
 
 from google.protobuf import json_format
@@ -124,4 +125,5 @@ class TestTransit(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    multiprocessing.set_start_method("spawn")
     unittest.main()


### PR DESCRIPTION
ProcessPoolExecutor defaults to fork, which generates a DeprecationWarning and a notice about possible deadlock. We are seeing timeouts for certain tests now, so lets move to a safer "spawn" method.

Ref: https://docs.python.org/3/library/os.html#os.fork