### PR TITLE
Add route type 400 and map to rail

### DIFF
--- a/src/gtfs_upcoming/schedule/database.py
+++ b/src/gtfs_upcoming/schedule/database.py
@@ -40,7 +40,10 @@ ROUTE_TYPES = {
     '6': 'AERIAL_LIFT',
     '7': 'FUNICULAR',
     '11': 'TROLLEYBUS',
-    '12': 'MONORAIL'
+    '12': 'MONORAIL',
+
+    # See: https://developers.google.com/transit/gtfs/reference/extended-route-types
+    '400': 'RAIL'
 }
 
 CALENDAR_DAYS = [


### PR DESCRIPTION
This is an extended route type for "urban rail" (see [1]). TV just started using this in their GTFS schedule data.

[1] https://developers.google.com/transit/gtfs/reference/extended-route-types